### PR TITLE
Fix multiple batch object bug

### DIFF
--- a/mockfirestore/async_client.py
+++ b/mockfirestore/async_client.py
@@ -67,11 +67,10 @@ class AsyncMockFirestore(MockFirestore):
         return AsyncTransaction(self, **kwargs)
 
     def batch(self):
-        if not isinstance(self._async_store_ref, BatchAsyncInternal):
-            new_batch_store_ref = BatchAsyncInternal()
-            new_batch_store_ref._data = deepcopy(self._async_store_ref._data) # noqa
-            del self._async_store_ref
-            self._async_store_ref = new_batch_store_ref
+        new_batch_store_ref = BatchAsyncInternal()
+        new_batch_store_ref._data = self._async_store_ref._data
+        del self._async_store_ref
+        self._async_store_ref = new_batch_store_ref
         return self._async_store_ref
 
 
@@ -79,13 +78,17 @@ class BatchAsyncInternal(AsyncMockFirestore):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._args = args
+        self._kwargs = kwargs
         self._ops_queue: List[FirestoreBatchOps] = []
 
     def __len__(self):
         return len(self._ops_queue)
 
     def batch(self):
-        return self
+        new_batch = BatchAsyncInternal(*self._args, **self._kwargs)
+        new_batch._data = self._data
+        return new_batch
 
     async def commit(self) -> List[Any]:
         results = []

--- a/mockfirestore/async_client.py
+++ b/mockfirestore/async_client.py
@@ -101,6 +101,7 @@ class BatchAsyncInternal(AsyncMockFirestore):
                 results.append(await op.doc_ref.delete())
             else:
                 raise NotImplementedError
+        self._ops_queue = []
         return results
 
     def set( # noqa

--- a/tests/test_async_batch.py
+++ b/tests/test_async_batch.py
@@ -52,15 +52,18 @@ class TestAsyncMockFirestore(aiounittest.AsyncTestCase):
         doc_ref_data_2 = [(coll_ref.document(key), datum) for (key, datum) in data_2]
 
         batch_1 = fs.batch()
+        batch_2 = fs.batch()
+        batch_3 = fs.batch()
+
         for doc_ref, datum in doc_ref_data_1:
             batch_1.set(doc_ref, datum)
         batch_1.delete(coll_ref.document("sample"))
-        await batch_1.commit()
-
-        batch_2 = fs.batch()
         for doc_ref, datum in doc_ref_data_2:
             batch_2.set(doc_ref, datum)
         batch_2.delete(coll_ref.document("quux"))
+        batch_3.delete(coll_ref.document("foo"))
+
+        await batch_1.commit()
         await batch_2.commit()
 
         assert fs._data == {

--- a/tests/test_async_batch.py
+++ b/tests/test_async_batch.py
@@ -1,0 +1,73 @@
+import aiounittest
+from mockfirestore import AsyncMockFirestore
+
+
+class TestAsyncMockFirestore(aiounittest.AsyncTestCase):
+    async def test_batch_commit(self):
+        fs = AsyncMockFirestore()
+        data = [
+            ("foo", {"value": "Foo"}),
+            ("bar", {"value": "Bar"}),
+            ("baz", {"value": "Baz"}),
+        ]
+        collection_path = "sample_collection"
+
+        batch_store = fs.batch()
+        coll_ref = fs.collection(collection_path)
+        doc_ref_data = [(coll_ref.document(key), datum) for (key, datum) in data]
+
+        # Batch write data
+        for doc_ref, datum in doc_ref_data:
+            batch_store.set(doc_ref, datum)
+        await batch_store.commit()
+
+        # Async sequential read
+        for doc_ref, datum in doc_ref_data:
+            result = await doc_ref.get()
+            assert result.exists
+            assert result.to_dict() == datum
+
+    async def test_batch_commit_multiple(self):
+        fs = AsyncMockFirestore()
+        collection_path = "sample_collection"
+        fs._data = {
+            collection_path: {
+                "sample": {"value": "Sample"}
+            }
+        }
+        data_1 = [
+            ("foo", {"value": "Foo"}),
+            ("bar", {"value": "Bar"}),
+            ("baz", {"value": "Baz"}),
+            ("quux", {"value": "Quux"})
+        ]
+        data_2 = [
+            ("foo", {"value": "Baz"}),
+            ("baz", {"value": "Foo"}),
+            ("qux", {"value": "Qux"})
+        ]
+
+        coll_ref = fs.collection(collection_path)
+        doc_ref_data_1 = [(coll_ref.document(key), datum) for (key, datum) in data_1]
+        doc_ref_data_2 = [(coll_ref.document(key), datum) for (key, datum) in data_2]
+
+        batch_1 = fs.batch()
+        for doc_ref, datum in doc_ref_data_1:
+            batch_1.set(doc_ref, datum)
+        batch_1.delete(coll_ref.document("sample"))
+        await batch_1.commit()
+
+        batch_2 = fs.batch()
+        for doc_ref, datum in doc_ref_data_2:
+            batch_2.set(doc_ref, datum)
+        batch_2.delete(coll_ref.document("quux"))
+        await batch_2.commit()
+
+        assert fs._data == {
+            collection_path: {
+                "foo": {"value": "Baz"},
+                "bar": {"value": "Bar"},
+                "baz": {"value": "Foo"},
+                "qux": {"value": "Qux"}
+            }
+        }


### PR DESCRIPTION
Previously if instantiate multiple `batch` object it will return only one object (singleton), to maintain single data source integrity. However, this will cause the batch queue to be mixed together and creating unexpected behaviour

In this fix, a new instance of `batch` object is create, but all the data source is pointed to the original dictionary object `self._data`. Therefore fixing the data source inconsistency problem 